### PR TITLE
Add stale-issues workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,13 @@
+name: Close stale issues
+
+on:
+  schedule:
+    - cron: '30 1 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  stale:
+    uses: ljmerza/misc-actions/.github/workflows/stale-issues.yml@main


### PR DESCRIPTION
## Summary

Adds a scheduled workflow that closes stale issues — 23 days inactive → `stale` label + warning comment, 7 more days inactive → closed (30 days total). PRs are untouched.

Logic is centralized in [`ljmerza/misc-actions`](https://github.com/ljmerza/misc-actions/blob/main/.github/workflows/stale-issues.yml); this file is just a 12-line caller.

Exempt labels: `pinned`, `security`, `help wanted`, `good first issue`.

## Test plan

- [ ] After merge, trigger via Actions → "Close stale issues" → "Run workflow" to confirm the job is green.
- [ ] Confirm no PRs are touched (workflow targets issues only).
- [ ] Optional: label a test issue `pinned` and re-run to confirm it's exempted.